### PR TITLE
[config] renew mdx extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,7 +9,7 @@
 		"aaron-bond.better-comments",
 		"dbaeumer.vscode-eslint",
 		"svelte.svelte-vscode",
-		"silvenon.mdx" //? MDSvex Language Support
+		"unifiedjs.vscode-mdx" //? MDSvex Language Support
 
 		/*
 		 * Honorable mentions


### PR DESCRIPTION
Makes VSCode recommend the VSCode MDX extension instead of the deprecated MDX extension.